### PR TITLE
Headers appear to be undefined every now and again

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats-nock-adapter",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "license": "MIT",
   "description": "nock server adapter for smartlyio/oats s",
   "private": false,

--- a/src/nock.ts
+++ b/src/nock.ts
@@ -191,7 +191,7 @@ export class Server<Spec> {
     nock(server)
       [method](getPathRegex(path))
       .reply(async function (uri, requestBody, cb) {
-        const body = getBody(this.req.headers['content-type'], requestBody);
+        const body = getBody(this.req.headers?.['content-type'], requestBody);
         const url = new URL('http://host-for-nock' + uri);
         try {
           const result = await nocked({


### PR DESCRIPTION
Getting from time to time... unsure why the headers are empty 🤔
```
TypeError: Cannot read property 'content-type' of undefined
           at Interceptor.fullReplyFunction (/app/node_modules/@smartlyio/oats-nock-adapter/src/nock.ts:194:46)
           at internal/util.js:297:30
           at new Promise (<anonymous>)
           at Interceptor.<anonymous> (internal/util.js:296:12)
           at start (/app/node_modules/nock/lib/playback_interceptor.js:177:26)
           at Immediate.<anonymous> (/app/node_modules/nock/lib/playback_interceptor.js:315:7)
           at processImmediate (internal/timers.js:456:21)
           at process.topLevelDomainCallback (domain.js:137:15)
```